### PR TITLE
Fix the link generation for MRs

### DIFF
--- a/gitlab.coffee
+++ b/gitlab.coffee
@@ -91,7 +91,7 @@ module.exports = (robot) ->
             when "issue"
               robot.send user, "Issue #{bold(hook.object_attributes.iid)}: #{hook.object_attributes.title} (#{hook.object_attributes.state}) at #{hook.object_attributes.url}"
             when "merge_request"
-              link = "https://code.siftware.com/#{encodeURI(hook.object_attributes.target.path_with_namespace)}/merge_requests/#{hook.object_attributes.iid}"
+              link = "https://code.siftware.com/#{encodeURI(hook.object_attributes.target.path_with_namespace)}/merge_requests/#{encodeURI(hook.object_attributes.iid)}"
 
               if hook.object_attributes.created_at == hook.object_attributes.updated_at
                 info = "New MR created \#"

--- a/gitlab.coffee
+++ b/gitlab.coffee
@@ -91,7 +91,7 @@ module.exports = (robot) ->
             when "issue"
               robot.send user, "Issue #{bold(hook.object_attributes.iid)}: #{hook.object_attributes.title} (#{hook.object_attributes.state}) at #{hook.object_attributes.url}"
             when "merge_request"
-              link = "https://code.siftware.com/#{encodeURI(hook.object_attributes.target.namespace.toLowerCase())}/#{encodeURI(hook.object_attributes.target.name.toLowerCase().replace / /, "")}/merge_requests/#{hook.object_attributes.iid}"
+              link = "https://code.siftware.com/#{encodeURI(hook.object_attributes.target.path_with_namespace)}/merge_requests/#{hook.object_attributes.iid}"
 
               if hook.object_attributes.created_at == hook.object_attributes.updated_at
                 info = "New MR created \#"


### PR DESCRIPTION
This uses the `path_with_namespace` value as documented here: https://gitlab.com/gitlab-org/gitlab-ce/blob/master/doc/web_hooks/web_hooks.md, rather than trying to build it ourselves.